### PR TITLE
Added External User OS Login role to organization

### DIFF
--- a/examples/gcp/bootstrap/main.tf
+++ b/examples/gcp/bootstrap/main.tf
@@ -1,5 +1,12 @@
 variable "name_prefix" {}
 variable "gcp_project" {}
+variable "organization_id" {
+  default = ""
+}
+variable "external_users" {
+  type    = list(string)
+  default = []
+}
 variable "enable_services" {
   default = true
 }
@@ -13,6 +20,8 @@ module "bootstrap" {
 
   name_prefix                   = var.name_prefix
   gcp_project                   = var.gcp_project
+  organization_id               = var.organization_id
+  external_users                = var.external_users
   enable_services               = var.enable_services
   tf_state_bucket_force_destroy = var.tf_state_bucket_force_destroy
 }

--- a/modules/bootstrap/gcp/external-user.tf
+++ b/modules/bootstrap/gcp/external-user.tf
@@ -1,0 +1,11 @@
+data "google_iam_policy" "external_users" {
+  binding {
+    role    = "roles/compute.osLoginExternalUser"
+    members = local.external_users
+  }
+}
+
+resource "google_organization_iam_policy" "external_users" {
+  count       = local.organization_id ? 1 : 0
+  policy_data = data.google_iam_policy.external_users.policy_data
+}

--- a/modules/bootstrap/gcp/variables.tf
+++ b/modules/bootstrap/gcp/variables.tf
@@ -1,5 +1,7 @@
 variable "name_prefix" {}
 variable "gcp_project" {}
+variable "organization_id" {}
+variable "external_users" {}
 variable "tf_state_bucket_location" {
   default = "US-EAST1"
 }
@@ -12,6 +14,8 @@ variable "enable_services" {
 
 locals {
   name_prefix                   = var.name_prefix
+  organization_id               = var.organization_id
+  external_users                = var.external_users
   tf_state_bucket_location      = var.tf_state_bucket_location
   tf_state_bucket_force_destroy = var.tf_state_bucket_force_destroy
   project                       = var.gcp_project


### PR DESCRIPTION
Adds `external_user` and `organization_id` variables to bootstrap phase.
External users should be of the format: "user:email@example.com"