### PR TITLE
chore: revoke credential on bastion setting exposed to variables

### DIFF
--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -20,6 +20,7 @@ export GALOY_ENVIRONMENT=${project}
 export KUBE_CONFIG_PATH=~/.kube/config
 EOF
 
+%{ if bastion_revoke_on_exit }
 cat <<EOF >> /etc/profile.d/auto-revoke.sh
 onExit() {
   gcloud auth revoke
@@ -27,6 +28,7 @@ onExit() {
 }
 trap onExit EXIT
 EOF
+%{ endif }
 
 curl -LO https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/amd64/kubectl
 chmod +x ./kubectl

--- a/modules/inception/gcp/bastion.tf
+++ b/modules/inception/gcp/bastion.tf
@@ -56,6 +56,7 @@ resource "google_compute_instance" "bastion" {
     cluster_name : "${local.name_prefix}-cluster",
     zone : local.region,
     project : local.project,
+    bastion_revoke_on_exit: local.bastion_revoke_on_exit
     cfssl_version : local.cfssl_version,
     bitcoin_version : local.bitcoin_version
     cepler_version : local.cepler_version

--- a/modules/inception/gcp/variables.tf
+++ b/modules/inception/gcp/variables.tf
@@ -12,6 +12,9 @@ variable "bastion_machine_type" {
 variable "bastion_image" {
   default = "ubuntu-os-cloud/ubuntu-2110"
 }
+variable "bastion_revoke_on_exit" {
+  default = true
+}
 variable "network_prefix" {
   default = "10.0"
 }
@@ -42,7 +45,8 @@ locals {
   region         = var.region
   network_prefix = var.network_prefix
 
-  bastion_zone         = "${local.region}-${var.primary_zone}"
-  bastion_machine_type = var.bastion_machine_type
-  bastion_image        = var.bastion_image
+  bastion_zone           = "${local.region}-${var.primary_zone}"
+  bastion_machine_type   = var.bastion_machine_type
+  bastion_image          = var.bastion_image
+  bastion_revoke_on_exit = var.bastion_revoke_on_exit
 }


### PR DESCRIPTION
Adds optional `bastion_revoke_on_exit` variable to set whether or not we are revoking credential on exiting ssh tunnel to bastion