### PR TITLE
fix: link to bitcoin binary

### DIFF
--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -44,7 +44,7 @@ wget https://github.com/bodymindarts/cepler/releases/download/v${cepler_version}
   && chmod +x /usr/local/bin/cepler \
   && rm -rf ./cepler-*
 
-wget https://bitcoin.org/bin/bitcoin-core-${bitcoin_version}/bitcoin-${bitcoin_version}-x86_64-linux-gnu.tar.gz \
+wget https://bitcoincore.org/bin/bitcoin-core-${bitcoin_version}/bitcoin-${bitcoin_version}-x86_64-linux-gnu.tar.gz \
   && tar -xvf bitcoin-${bitcoin_version}-x86_64-linux-gnu.tar.gz \
   && mv bitcoin-${bitcoin_version}/bin/* /usr/local/bin
 


### PR DESCRIPTION
bitcoin.org is blocked in the UK due to legal proceedings involving the site owner
bitcoincore.org has a different ownership and therefore a more reliable source

Test:
https://bitcoin.org/bin/bitcoin-core-22.0/
leads to a 404 error froma  UK IP address

https://bitcoincore.org/bin/bitcoin-core-22.0/
is available from everywhere