### PR TITLE
fix: add monitoring access to platform users

### DIFF
--- a/modules/inception/gcp/platform-roles.tf
+++ b/modules/inception/gcp/platform-roles.tf
@@ -57,6 +57,7 @@ resource "google_project_iam_custom_role" "platform_make" {
     "cloudsql.users.create",
     "cloudsql.users.list",
     "cloudsql.instances.list",
+    "monitoring.timeSeries.list",
   ]
 }
 


### PR DESCRIPTION
opened in place of https://github.com/GaloyMoney/galoy-deployments/pull/1701 