### PR TITLE
fix: add permissions to platform make group

### DIFF
--- a/modules/inception/gcp/platform-roles.tf
+++ b/modules/inception/gcp/platform-roles.tf
@@ -54,10 +54,13 @@ resource "google_project_iam_custom_role" "platform_make" {
     "cloudsql.instances.create",
     "cloudsql.instances.get",
     "cloudsql.instances.update",
-    "cloudsql.instances.patch",
+    "cloudsql.instances.list",
+    "cloudsql.databases.create",
+    "cloudsql.databases.get",
+    "cloudsql.databases.list",
+    "cloudsql.databases.update",
     "cloudsql.users.create",
     "cloudsql.users.list",
-    "cloudsql.instances.list",
     "monitoring.timeSeries.list",
   ]
 }


### PR DESCRIPTION
reverting: https://github.com/GaloyMoney/galoy-infra/pull/57 to fix https://ci.galoy.io/teams/dev/pipelines/galoy-infra/jobs/gcp-testflight-inception/builds/6

Related: https://github.com/GaloyMoney/galoy-infra/pull/56

docs reference: https://cloud.google.com/sql/docs/mysql/iam-roles#roles