### PR TITLE
fix!: bastion internet access needs nat

### DIFF
--- a/modules/inception/gcp/nat.tf
+++ b/modules/inception/gcp/nat.tf
@@ -2,7 +2,7 @@ resource "google_compute_router" "router" {
   name    = "${local.name_prefix}-router"
   project = local.project
   region  = local.region
-  network = data.google_compute_network.vpc.self_link
+  network = google_compute_network.vpc.self_link
   bgp {
     asn = 64514
   }


### PR DESCRIPTION
Looks like without external IP on the VPC, to give Internet access to the bastion (which lets the startup script run properly) we need the NAT. 

https://serverfault.com/questions/947970/google-compute-engine-trouble-accessing-internet-from-an-instance-without-exter

Moved the NAT from platform to inception.
Tested locally and working!

My assumption is there was some race condition between GCE running the startup script and platform applying the NAT which is why on the CI it was not reliably failing?