### PR TITLE
chore: add vault to bastion startup script

### DIFF
--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -7,7 +7,7 @@ apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_re
 
 # Keep make and terraform the first items installed as they are needed
 # for testflight to complete
-apt-get update && apt-get install -y make terraform jq tree wget redis postgresql
+apt-get update && apt-get install -y make terraform jq tree wget redis postgresql vault
 
 gcloud components install gke-gcloud-auth-plugin
 


### PR DESCRIPTION
Since we already add the hashicorp repo, vault should be available to install without any other changes.