### PR TITLE
fix: switch to installing gke auth plugin from apt

### DIFF
--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -5,11 +5,12 @@ sed -i'' 's/pam_mkhomedir.so$/pam_mkhomedir.so umask=0077/' /etc/pam.d/sshd # Ma
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+apt-add-repository "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main"
+
 # Keep make and terraform the first items installed as they are needed
 # for testflight to complete
-apt-get update && apt-get install -y make terraform jq tree wget redis postgresql vault
-
-gcloud components install gke-gcloud-auth-plugin
+apt-get update && apt-get install -y make terraform jq tree wget redis postgresql vault google-cloud-sdk-gke-gcloud-auth-plugin
 
 cat <<EOF > /etc/profile.d/aliases.sh
 alias tf="terraform"


### PR DESCRIPTION
`gcloud components install gke-gcloud-auth-plugin` returns the following error:
```
ERROR: (gcloud.components.install) You cannot perform this action because this Google Cloud CLI installation is managed by an external package manager.
Please consider using a separate installation of the Google Cloud CLI created through the default mechanism described at: https://cloud.google.com/sdk/
```

We'll have to install it from apt instead