### PR TITLE
Fix-bastion-errors

### DIFF
--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -10,7 +10,7 @@ apt-add-repository "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https:/
 
 # Keep make and terraform the first items installed as they are needed
 # for testflight to complete
-apt-get update && apt-get install -y make terraform jq tree wget redis postgresql vault
+apt-get update && apt-get install -y make terraform jq tree wget redis postgresql vault google-cloud-sdk-gke-gcloud-auth-plugin
 
 cat <<EOF > /etc/profile.d/aliases.sh
 alias tf="terraform"

--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -5,12 +5,12 @@ sed -i'' 's/pam_mkhomedir.so$/pam_mkhomedir.so umask=0077/' /etc/pam.d/sshd # Ma
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-apt-add-repository "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main"
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
 # Keep make and terraform the first items installed as they are needed
 # for testflight to complete
-apt-get update && apt-get install -y make terraform jq tree wget redis postgresql vault google-cloud-sdk-gke-gcloud-auth-plugin
+apt-get update && apt-get install -y make terraform jq tree wget redis postgresql vault
 
 cat <<EOF > /etc/profile.d/aliases.sh
 alias tf="terraform"
@@ -73,3 +73,5 @@ curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && npm config set prefix '/usr' \
   && npm i -g balanceofsatoshis@${bos_version} \
   && ln -s ../lib/node_modules/balanceofsatoshis/bos /usr/bin/
+
+apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin

--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -21,7 +21,7 @@ alias kauth="gcloud container clusters get-credentials ${cluster_name} --zone ${
 
 export GALOY_ENVIRONMENT=${project}
 export KUBE_CONFIG_PATH=~/.kube/config
-bos completion bash
+source <(bos completion bash)
 EOF
 
 %{ if bastion_revoke_on_exit }


### PR DESCRIPTION
Fixing the errors seen when logging in to the bastions:

- bos completion needs to be sourced, not displayed

- the error needing the `gke-gcloud-auth-plugin` is displayed when running: `kauth`:

```
openoms_galoy_io@galoy-staging-bastion:~$ kauth
Fetching cluster endpoint and auth data.
CRITICAL: ACTION REQUIRED: gke-gcloud-auth-plugin, which is needed for continued use of kubectl, was not found or is not executable. Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
kubeconfig entry generated for galoy-staging-cluster.
```

this needs to be installed with apt