### PR TITLE
feat: add k8sattributes to otel tracing

### DIFF
--- a/modules/services/opentelemetry-values.yml
+++ b/modules/services/opentelemetry-values.yml
@@ -67,7 +67,25 @@ config:
       timeout: 5s
       override: false
     k8sattributes:
-      passthrough: true
+      auth_type: "serviceAccount"
+      passthrough: false
+      filter:
+        node_from_env_var: KUBE_NODE_NAME
+      extract:
+        metadata:
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.deployment.name
+          - k8s.cluster.name
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.start_time
+      pod_association:
+        - from: resource_attribute
+          name: k8s.pod.ip
+        - from: resource_attribute
+          name: k8s.pod.uid
+        - from: connection
   receivers:
     jaeger:
       protocols:
@@ -102,6 +120,7 @@ config:
           - logging
         processors:
           - memory_limiter
+          - k8sattributes
           - batch
         receivers:
           - otlp
@@ -110,6 +129,7 @@ config:
           - logging
         processors:
           - memory_limiter
+          - k8sattributes
           - batch
         receivers:
           - otlp


### PR DESCRIPTION
Used the config from https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#section-readme with some inspiration from https://github.com/newrelic-experimental/otel-workshop/blob/efc49476d66fde177cc890b89443c8b23ca706b5/src/otel-collector-agent/collector.yaml#L27