### PR TITLE
feat: add k8sattributes in collector mode

### DIFF
--- a/modules/services/opentelemetry-values.yml
+++ b/modules/services/opentelemetry-values.yml
@@ -1,3 +1,9 @@
+clusterRole:
+  create: true
+  rules:
+  - apiGroups: [""]
+    resources: ["pods", "namespaces"]
+    verbs: ["get", "watch", "list"]
 agentCollector:
   enabled: false
 standaloneCollector:
@@ -67,7 +73,27 @@ config:
       timeout: 5s
       override: false
     k8sattributes:
+    k8sattributes/2:
+      auth_type: "serviceAccount"
       passthrough: true
+      filter:
+        node_from_env_var: KUBE_NODE_NAME
+
+      extract:
+        metadata:
+          - k8s.pod.name
+          - k8s.pod.uid
+          - k8s.deployment.name
+          - k8s.namespace.name
+          - k8s.node.name
+          - k8s.pod.start_time
+
+      pod_association:
+      - from: resource_attribute
+        name: k8s.pod.ip
+      - from: resource_attribute
+        name: k8s.pod.uid
+      - from: connection
   receivers:
     jaeger:
       protocols:


### PR DESCRIPTION
Kind of testing, but have a good feeling about this.

Following the [documentation](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor#section-readme), we need the cluster roles attached to the collector along with specifying which metadata to extract and pod_association resource attributes.

Those things have been added in this PR.

(Aside) Locally, no `k8s` data gets pushed to Honeycomb, which is strange. Maybe k3d doesn't have integrations?