### PR TITLE
chore: ingress class make default

### DIFF
--- a/modules/services/ingress-values.yml.tmpl
+++ b/modules/services/ingress-values.yml.tmpl
@@ -1,4 +1,7 @@
 controller:
+  ingressClassResource:
+    default: true
+    watchIngressWithoutClass: true
   config:
     enable-opentracing: "true"
     jaeger-service-name: ${service_name}


### PR DESCRIPTION
NGINX Ingress Controller upgrade for `networking.k8s.io/v1`.
https://kubernetes.github.io/ingress-nginx/#faq-migration-to-apiversion-networkingk8siov1

This PR:
- Makes this the default ingress controller for the cluster.
- Watches Ingress without class so that even if `spec.ingressClassName` is not set in `kind: Ingress`, nginx ingress controller still works for them.