### PR TITLE
chore!: upgrade cluster to Kubernetes 1.22

### DIFF
--- a/ci/k8s-upgrade/main.tf
+++ b/ci/k8s-upgrade/main.tf
@@ -1,7 +1,7 @@
 data "google_container_engine_versions" "central1b" {
   provider       = google-beta
   location       = "us-central1"
-  version_prefix = "1.21."
+  version_prefix = "1.22."
   project        = "*"
 }
 


### PR DESCRIPTION
Updated CI to make sure the bumps henceforth are for K8s 1.22