### PR TITLE
Revert "chore: add kafkatopic permissions to smoketest svc account"

### DIFF
--- a/modules/services/smoketest.tf
+++ b/modules/services/smoketest.tf
@@ -15,12 +15,6 @@ resource "kubernetes_role" "smoketest" {
     resources  = ["secrets"]
     verbs      = ["get", "list"]
   }
-
-  rule {
-    api_groups = ["kafka.strimzi.io"]
-    resources  = ["kafkatopics"]
-    verbs      = ["get", "create", "delete"]
-  }
 }
 
 resource "kubernetes_service_account" "smoketest" {


### PR DESCRIPTION
Reverts GaloyMoney/galoy-infra#100

The permission is granted only for the smoketest namespace, however kafka operator is incapable of watching that namespace as it's deployed to its own dedicated namespace. Hence, these permissions are never used.