### PR TITLE
fix: create svc acc token manually

### DIFF
--- a/modules/smoketest/gcp/main.tf
+++ b/modules/smoketest/gcp/main.tf
@@ -24,9 +24,21 @@ resource "kubernetes_service_account" "smoketest" {
   }
 }
 
+resource "kubernetes_secret" "smoketest_token" {
+  metadata {
+    name      = "${local.smoketest_name}-token"
+    namespace = kubernetes_namespace.smoketest.metadata[0].name
+    annotations = {
+      "kubernetes.io/service-account.name" = kubernetes_service_account.smoketest.metadata[0].name
+    }
+  }
+
+  type = "kubernetes.io/service-account-token"
+}
+
 data "kubernetes_secret" "smoketest_token" {
   metadata {
-    name      = kubernetes_service_account.smoketest.default_secret_name
+    name      = kubernetes_secret.smoketest_token.metadata[0].name
     namespace = kubernetes_namespace.smoketest.metadata[0].name
   }
 }


### PR DESCRIPTION
From k8s `v1.24.0` onwards, a token for the service account is not created automatically, and so needs to be created manually.

Relevant error from provider -
```
│ Warning: "default_secret_name" is no longer applicable for Kubernetes v1.24.0 and above
│
│ Starting from version 1.24.0 Kubernetes does not automatically generate a token for service accounts, in this case, "default_secret_name" will be empty
```