### PR TITLE
chore: bastion update bitcoin, kubectl, kratos

### DIFF
--- a/modules/inception/gcp/bastion.tf
+++ b/modules/inception/gcp/bastion.tf
@@ -1,14 +1,14 @@
 locals {
   tag             = "${local.name_prefix}-bastion"
   cfssl_version   = "1.6.1"
-  bitcoin_version = "23.0"
+  bitcoin_version = "24.0.1"
   cepler_version  = "0.7.9"
   safe_version    = "1.7.0"
   lnd_version     = "0.15.5"
-  kubectl_version = "1.21.9"
+  kubectl_version = "1.23.5"
   k9s_version     = "0.25.18"
   bos_version     = "12.13.3"
-  kratos_version  = "0.10.1"
+  kratos_version  = "0.11.1"
 }
 
 resource "google_compute_instance" "bastion" {


### PR DESCRIPTION
Using the latest LTS image:
https://github.com/GaloyMoney/galoy-infra/blob/7c8d479be46396a196675ab3829520205d1967cb/modules/inception/gcp/variables.tf#L16
```
gcloud compute images list | grep ubuntu-2204-lts

ubuntu-2204-jammy-v20230114                           ubuntu-os-cloud      ubuntu-2204-lts
```