### PR TITLE
fix: specify project id in k8s upgrader

### DIFF
--- a/ci/k8s-upgrade/main.tf
+++ b/ci/k8s-upgrade/main.tf
@@ -2,7 +2,7 @@ data "google_container_engine_versions" "central1b" {
   provider       = google-beta
   location       = "us-central1"
   version_prefix = "1.27."
-  project        = "*"
+  project        = "galoy-infra-testflight"
 }
 
 output "latest_version" {


### PR DESCRIPTION
It looks like either gcp or the provider no longer allow `*` to be passed in as the project id.
