### PR TITLE
fix: add get project perm to destroy inception

### DIFF
--- a/ci/tasks/gcp/teardown.sh
+++ b/ci/tasks/gcp/teardown.sh
@@ -36,8 +36,8 @@ for i in {1..5}; do
   sleep 10
 done
 
-if [ $success -eq 0 ]; then
-  exit 1
-else
+if [ $success -eq 1 ]; then
   echo yes | TF_VAR_tf_state_bucket_force_destroy=true make destroy-bootstrap
+else
+  exit 1
 fi

--- a/ci/tasks/gcp/teardown.sh
+++ b/ci/tasks/gcp/teardown.sh
@@ -29,11 +29,15 @@ gcloud compute ssh --ssh-key-file=${CI_ROOT}/login.ssh ${bastion_name} --zone=${
 echo yes | make destroy-platform
 
 # Sometimes a resource deletion fails if a dependent resource is still being deleted
+success=0
 for i in {1..5}; do
-  echo yes | GOOGLE_CREDENTIALS=$(cat inception-sa-creds.json) make destroy-inception && break
-  echo "Attempt $i failed. Retrying..."
+  echo "Attempt $i to destroy inception"
+  echo yes | GOOGLE_CREDENTIALS=$(cat inception-sa-creds.json) make destroy-inception && success=1 && break
   sleep 10
 done
 
-echo yes | TF_VAR_tf_state_bucket_force_destroy=true make destroy-bootstrap
-
+if [ $success -eq 0 ]; then
+  exit 1
+else
+  echo yes | TF_VAR_tf_state_bucket_force_destroy=true make destroy-bootstrap
+fi

--- a/modules/inception/gcp/inception-roles.tf
+++ b/modules/inception/gcp/inception-roles.tf
@@ -64,6 +64,7 @@ resource "google_project_iam_custom_role" "inception_destroy" {
     "iam.serviceAccounts.delete",
     "iam.roles.delete",
     "storage.buckets.delete",
+    "resourcemanager.projects.get",
     "servicenetworking.services.get",
     "servicenetworking.services.deleteConnection",
     "serviceusage.operations.get"


### PR DESCRIPTION
I have tested the perm by adding it to a service account, impersonating it and trying to delete the `google_service_networking_connection` resource.