### PR TITLE
fix: networking connection resource dependency

### DIFF
--- a/modules/inception/gcp/network.tf
+++ b/modules/inception/gcp/network.tf
@@ -37,4 +37,6 @@ resource "google_service_networking_connection" "service" {
   network                 = google_compute_network.vpc.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.peering.name]
+
+  depends_on = [google_project_iam_member.inception_destroy]
 }


### PR DESCRIPTION
The google_service_networking_connection resource deletion is happening after the iam member gets deleted, so the service account does not have the necessary permissions to execute deletion.
