### PR TITLE
chore: enable iap audit logs

### DIFF
--- a/modules/inception/gcp/bastion.tf
+++ b/modules/inception/gcp/bastion.tf
@@ -101,3 +101,17 @@ resource "google_compute_firewall" "bastion_allow_iap_inbound" {
     ports    = [22]
   }
 }
+
+resource "google_project_iam_audit_config" "iap_audit_logs" {
+  project = local.project
+  service = "iap.googleapis.com"
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_WRITE"
+  }
+}


### PR DESCRIPTION
Not sure if `bastion.tf` is the right place for this resource to be in, or if there's a more apt location.