### PR TITLE
fix: downgrade gke to version available on all regions

### DIFF
--- a/modules/platform/gcp/variables.tf
+++ b/modules/platform/gcp/variables.tf
@@ -10,7 +10,7 @@ variable "network_prefix" {
   default = "10.1"
 }
 variable "kube_version" {
-  default = "1.27.13-gke.1166000"
+  default = "1.27.13-gke.1000000"
 }
 variable "node_default_machine_type" {
   default = "n2-standard-4"


### PR DESCRIPTION
The latest on east1 is not available on central1, and the reverse is also true. So downgrading and pausing the upgrade for sometime till the latest is rolled out to all regions.