### PR TITLE
fix: use netcat-traditional instead of netcat

### DIFF
--- a/ci/image/gcp/Dockerfile
+++ b/ci/image/gcp/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
   libtool autotools-dev autoconf libssl-dev libboost-all-dev \
   apt-transport-https ca-certificates \
   gnupg software-properties-common \
-  vim jq rsync wget netcat \
+  vim jq rsync wget netcat-traditional \
   unzip \
   && apt-get clean all
 


### PR DESCRIPTION
Building the image with docker fails because of `netcat` package. This PR uses the `netcat-traditional` instead, which is a potential fix to the issue.

https://forums.docker.com/t/package-netcat-has-no-installation-candidate-how-to-fix-this/136541/3