### PR TITLE
chore: pg replica depend on master

### DIFF
--- a/examples/gcp/postgresql/main.tf
+++ b/examples/gcp/postgresql/main.tf
@@ -1,4 +1,5 @@
 variable "name_prefix" {}
+variable "vpc_name_prefix" {}
 variable "gcp_project" {}
 variable "destroyable_postgres" {
   default = false
@@ -9,7 +10,7 @@ module "postgresql" {
   # source = "../../../modules/postgresql/gcp"
 
   instance_name          = "${var.name_prefix}-pg"
-  vpc_name               = "${var.name_prefix}-vpc"
+  vpc_name               = "${var.vpc_name_prefix}-vpc"
   gcp_project            = var.gcp_project
   destroyable            = var.destroyable_postgres
   user_can_create_db     = true

--- a/examples/gcp/postgresql/main.tf
+++ b/examples/gcp/postgresql/main.tf
@@ -1,5 +1,4 @@
 variable "name_prefix" {}
-variable "vpc_name_prefix" {}
 variable "gcp_project" {}
 variable "destroyable_postgres" {
   default = false
@@ -10,7 +9,7 @@ module "postgresql" {
   # source = "../../../modules/postgresql/gcp"
 
   instance_name          = "${var.name_prefix}-pg"
-  vpc_name               = "${var.vpc_name_prefix}-vpc"
+  vpc_name               = "${var.name_prefix}-vpc"
   gcp_project            = var.gcp_project
   destroyable            = var.destroyable_postgres
   user_can_create_db     = true

--- a/modules/postgresql/gcp/read-replica.tf
+++ b/modules/postgresql/gcp/read-replica.tf
@@ -1,13 +1,12 @@
 resource "google_sql_database_instance" "replica" {
   count                = local.provision_read_replica ? 1 : 0
   name                 = "${local.instance_name}-${random_id.db_name_suffix.hex}-replica"
-  master_instance_name = "${local.instance_name}-${random_id.db_name_suffix.hex}"
+  master_instance_name = google_sql_database_instance.instance.name
 
   project             = local.gcp_project
   database_version    = "POSTGRES_14"
   region              = local.region
   deletion_protection = !local.destroyable
-  depends_on          = [google_sql_database_instance.instance]
 
   settings {
     tier              = local.tier

--- a/modules/postgresql/gcp/read-replica.tf
+++ b/modules/postgresql/gcp/read-replica.tf
@@ -7,6 +7,7 @@ resource "google_sql_database_instance" "replica" {
   database_version    = "POSTGRES_14"
   region              = local.region
   deletion_protection = !local.destroyable
+  depends_on          = [google_sql_database_instance.instance]
 
   settings {
     tier              = local.tier


### PR DESCRIPTION
This PR addresses the issue where running the `terraform apply` command results in a failure due to the creation of `replica` and `master` in **parallel**, which caused permission errors. 