### PR TITLE
feat: Conditionally prepare source instance for migration

### DIFF
--- a/modules/postgresql/gcp/database/main.tf
+++ b/modules/postgresql/gcp/database/main.tf
@@ -5,6 +5,7 @@ variable "user_name" {}
 variable "user_can_create_db" {}
 variable "pg_instance_connection_name" {}
 variable "replication" {}
+variable "upgradable" {}
 variable "connection_users" {
   type = list(string)
 }
@@ -53,6 +54,13 @@ resource "postgresql_database" "db" {
   owner      = var.admin_user_name
   template   = "template0"
   lc_collate = "en_US.UTF8"
+}
+
+resource "postgresql_extension" "pglogical" {
+  count      = var.upgradable ? 1 : 0
+  name       = "pglogical"
+  database   = var.db_name
+  depends_on = [postgresql_database.db]
 }
 
 resource "postgresql_grant" "revoke_public" {

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -133,7 +133,7 @@ resource "null_resource" "grant_replication" {
       -p ${local.database_port} \
       -U ${google_sql_user.admin.name} \
       -d postgres \
-      -c "ALTER USER '${google_sql_user.admin.name}' WITH REPLICATION;"
+      -c 'ALTER USER "${google_sql_user.admin.name}" WITH REPLICATION;'
     EOT
   }
 

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -21,7 +21,7 @@ resource "google_sql_database_instance" "instance" {
     deletion_protection_enabled = !local.destroyable
 
     dynamic "database_flags" {
-      for_each = local.dms_upgradable ? [{
+      for_each = local.enable_logical_replication ? [{
         name  = "cloudsql.logical_decoding"
         value = "on"
         }, {

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -21,6 +21,20 @@ resource "google_sql_database_instance" "instance" {
     deletion_protection_enabled = !local.destroyable
 
     dynamic "database_flags" {
+      for_each = local.dms_upgradable ? [{
+        name  = "cloudsql.logical_decoding"
+        value = "on"
+        }, {
+        name  = "cloudsql.enable_pglogical"
+        value = "on"
+      }] : []
+      content {
+        name  = database_flags.value.name
+        value = database_flags.value.value
+      }
+    }
+
+    dynamic "database_flags" {
       for_each = local.max_connections > 0 ? [local.max_connections] : []
       content {
         name  = "max_connections"

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -51,7 +51,12 @@ resource "google_sql_database_instance" "instance" {
         }, {
         name  = "cloudsql.enable_pglogical"
         value = "on"
-      }] : []
+        }, {
+        # for exporting users after the database is migrated
+        name  = "cloudsql.pg_shadow_select_role"
+        value = "${local.instance_name}-admin"
+        }
+      ] : []
       content {
         name  = database_flags.value.name
         value = database_flags.value.value

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -15,6 +15,7 @@ resource "postgresql_extension" "pglogical" {
 
 resource "google_database_migration_service_connection_profile" "connection_profile" {
   count                 = local.upgradable ? 1 : 0
+  project               = local.gcp_project
   location              = local.region
   connection_profile_id = "${google_sql_database_instance.instance.name}-id"
   display_name          = "${google_sql_database_instance.instance.name}-connection-profile"

--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -51,6 +51,12 @@ variable "upgradable" {
   default     = false
 }
 
+variable "database_port" {
+  description = "Instance is upgradable via Database Migration Service"
+  type        = number
+  default     = 5432
+}
+
 locals {
   gcp_project                   = var.gcp_project
   vpc_name                      = var.vpc_name
@@ -67,4 +73,5 @@ locals {
   provision_read_replica        = var.provision_read_replica
   big_query_connection_location = var.big_query_connection_location
   upgradable                    = var.upgradable
+  database_port                 = var.database_port
 }

--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -48,7 +48,7 @@ variable "big_query_connection_location" {
 variable "dms_upgradable" {
   description = "Instance is upgradable via Database Migration Service"
   type        = bool
-  default     = true 
+  default     = true
 }
 
 locals {

--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -45,6 +45,11 @@ variable "provision_read_replica" {
 variable "big_query_connection_location" {
   default = "US"
 }
+variable "dms_upgradable" {
+  description = "Instance is upgradable via Database Migration Service"
+  type        = bool
+  default     = true 
+}
 
 locals {
   gcp_project                   = var.gcp_project
@@ -61,4 +66,5 @@ locals {
   replication                   = var.replication
   provision_read_replica        = var.provision_read_replica
   big_query_connection_location = var.big_query_connection_location
+  dms_upgradable                = var.dms_upgradable
 }

--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -45,10 +45,10 @@ variable "provision_read_replica" {
 variable "big_query_connection_location" {
   default = "US"
 }
-variable "dms_upgradable" {
+variable "enable_logical_replication" {
   description = "Instance is upgradable via Database Migration Service"
   type        = bool
-  default     = true
+  default     = false
 }
 
 locals {
@@ -66,5 +66,5 @@ locals {
   replication                   = var.replication
   provision_read_replica        = var.provision_read_replica
   big_query_connection_location = var.big_query_connection_location
-  dms_upgradable                = var.dms_upgradable
+  enable_logical_replication    = var.enable_logical_replication
 }

--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -45,7 +45,7 @@ variable "provision_read_replica" {
 variable "big_query_connection_location" {
   default = "US"
 }
-variable "enable_logical_replication" {
+variable "upgradable" {
   description = "Instance is upgradable via Database Migration Service"
   type        = bool
   default     = false
@@ -66,5 +66,5 @@ locals {
   replication                   = var.replication
   provision_read_replica        = var.provision_read_replica
   big_query_connection_location = var.big_query_connection_location
-  enable_logical_replication    = var.enable_logical_replication
+  upgradable                    = var.upgradable
 }


### PR DESCRIPTION
This PR prepares the source postgresql database for database update using the database migration service, with a simple `upgradable` flag. Once the flag is enabled it does the following things:
- enables `cloudsql.logical_decoding` and `cloudsql.enable_pglogical` flags
- Installs `pglogical` extension for all users.
- Creates a connection profile which is required by the database migration service for migration.

**Reference**
- https://cloud.google.com/database-migration/docs/postgres/configure-source-database#cloud-sql-postgresql
- https://cloud.google.com/database-migration/docs/postgres/configure-source-database