### PR TITLE
fix: Use netcat-bsd instead of traditional

### DIFF
--- a/ci/image/gcp/Dockerfile
+++ b/ci/image/gcp/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
   libtool autotools-dev autoconf libssl-dev libboost-all-dev \
   apt-transport-https ca-certificates \
   gnupg software-properties-common \
-  vim jq rsync wget netcat-traditional \
+  vim jq rsync wget netcat-openbsd \
   unzip \
   && apt-get clean all
 


### PR DESCRIPTION
This PR replaces `netcat-traditional` with `netcat-bsd` in `ci/image/gcp/Dockerfile`, as the former is not maintained since 1 year.