### PR TITLE
feat: Use migration user instead of database admin for migration

### DIFF
--- a/modules/postgresql/gcp/database/main.tf
+++ b/modules/postgresql/gcp/database/main.tf
@@ -129,6 +129,7 @@ resource "postgresql_grant" "big_query_connect" {
     postgresql_grant.grant_all
   ]
 }
+
 resource "postgresql_grant" "big_query_select" {
   database    = postgresql_database.db.name
   role        = postgresql_role.big_query.name

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -158,6 +158,7 @@ resource "postgresql_grant" "grant_usage_pglogical" {
   privileges = ["USAGE"]
 
   depends_on = [
+    postgresql_extension.pglogical,
     postgresql_role.migration
   ]
 }
@@ -173,7 +174,8 @@ resource "postgresql_grant" "grant_select_pglogical" {
   privileges = ["SELECT"]
 
   depends_on = [
-    postgresql_role.migration
+    postgresql_role.migration,
+    postgresql_extension.pglogical
   ]
 }
 

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -134,7 +134,6 @@ resource "postgresql_role" "migration" {
   replication = true
 }
 
-# GRANT CONNECT all the database
 resource "postgresql_grant" "grant_connect_db_migration_user" {
   for_each    = local.upgradable ? toset(local.migration_databases) : []
   database    = each.value
@@ -146,7 +145,6 @@ resource "postgresql_grant" "grant_connect_db_migration_user" {
   ]
 }
 
-# GRANT USAGE on SCHEMA SCHEMA to USER on all schemas (aside from the information schema and schemas starting with "pg_") on each database to migrate.
 resource "postgresql_grant" "grant_usage_public_schema_migration_user" {
   for_each    = local.upgradable ? toset(local.migration_databases) : []
   database    = each.value
@@ -176,7 +174,6 @@ resource "postgresql_grant" "grant_usage_pglogical_schema_migration_user" {
   ]
 }
 
-# GRANT USAGE on SCHEMA pglogical to PUBLIC; on each database to migrate.
 resource "postgresql_grant" "grant_usage_pglogical_schema_public_user" {
   for_each    = local.upgradable ? toset(local.migration_databases) : []
   database    = each.value
@@ -192,7 +189,6 @@ resource "postgresql_grant" "grant_usage_pglogical_schema_public_user" {
   ]
 }
 
-# GRANT SELECT on ALL TABLES in SCHEMA pglogical to USER on all databases to get replication information from source databases.
 resource "postgresql_grant" "grant_select_table_pglogical_schema_migration_user" {
   for_each    = local.upgradable ? toset(local.migration_databases) : []
   database    = each.value
@@ -208,7 +204,6 @@ resource "postgresql_grant" "grant_select_table_pglogical_schema_migration_user"
   ]
 }
 
-# GRANT SELECT on ALL TABLES in SCHEMA SCHEMA to USER on all schemas (aside from the information schema and schemas starting with "pg_") on each database to migrate.
 resource "postgresql_grant" "grant_select_table_public_schema_migration_user" {
   for_each    = local.upgradable ? toset(local.migration_databases) : []
   database    = each.value

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -54,12 +54,7 @@ resource "google_sql_database_instance" "instance" {
         }, {
         name  = "cloudsql.enable_pglogical"
         value = "on"
-        }, {
-        # for exporting users after the database is migrated
-        name  = "cloudsql.pg_shadow_select_role"
-        value = "${local.instance_name}-admin"
-        }
-      ] : []
+      }] : []
       content {
         name  = database_flags.value.name
         value = database_flags.value.value

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -192,22 +192,8 @@ resource "postgresql_grant" "grant_usage_pglogical_schema_public_user" {
   ]
 }
 
-resource "postgresql_grant" "grant_select_db_migration_user" {
-  for_each    = local.upgradable ? toset(local.migration_databases) : []
-  database    = each.value
-  role        = postgresql_role.migration[0].name
-  object_type = "database"
-
-  privileges = ["SELECT"]
-
-  depends_on = [
-    postgresql_extension.pglogical,
-    postgresql_role.migration
-  ]
-}
-
 # GRANT SELECT on ALL TABLES in SCHEMA pglogical to USER on all databases to get replication information from source databases.
-resource "postgresql_grant" "grant_select_pglogical_schema_migration_user" {
+resource "postgresql_grant" "grant_select_table_pglogical_schema_migration_user" {
   for_each    = local.upgradable ? toset(local.databases) : []
   database    = each.value
   role        = postgresql_role.migration[0].name
@@ -223,7 +209,7 @@ resource "postgresql_grant" "grant_select_pglogical_schema_migration_user" {
 }
 
 # GRANT SELECT on ALL TABLES in SCHEMA SCHEMA to USER on all schemas (aside from the information schema and schemas starting with "pg_") on each database to migrate.
-resource "postgresql_grant" "grant_select_public_schema_migration_user" {
+resource "postgresql_grant" "grant_select_table_public_schema_migration_user" {
   for_each    = local.upgradable ? toset(local.databases) : []
   database    = each.value
   role        = postgresql_role.migration[0].name

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -160,20 +160,6 @@ resource "postgresql_grant" "grant_usage_public_schema_migration_user" {
   ]
 }
 
-resource "postgresql_grant" "grant_select_pglogical_schema_migration_user" {
-  for_each    = local.upgradable ? toset(local.migration_databases) : []
-  database    = each.value
-  role        = postgresql_role.migration[0].name
-  schema      = "pglogical"
-  object_type = "database"
-
-  privileges = ["SELECT"]
-
-  depends_on = [
-    postgresql_extension.pglogical,
-    postgresql_role.migration
-  ]
-}
 
 resource "postgresql_grant" "grant_usage_pglogical_schema_migration_user" {
   for_each    = local.upgradable ? toset(local.migration_databases) : []
@@ -199,6 +185,20 @@ resource "postgresql_grant" "grant_usage_pglogical_schema_public_user" {
   object_type = "schema"
 
   privileges = ["USAGE"]
+
+  depends_on = [
+    postgresql_extension.pglogical,
+    postgresql_role.migration
+  ]
+}
+
+resource "postgresql_grant" "grant_select_db_migration_user" {
+  for_each    = local.upgradable ? toset(local.migration_databases) : []
+  database    = each.value
+  role        = postgresql_role.migration[0].name
+  object_type = "database"
+
+  privileges = ["SELECT"]
 
   depends_on = [
     postgresql_extension.pglogical,

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -167,7 +167,7 @@ resource "postgresql_grant" "grant_usage_postgres" {
   schema      = "pglogical"
   object_type = "schema"
 
-  privileges = ["USAGE"]
+  privileges = ["USAGE", "SELECT"]
 
   depends_on = [
     postgresql_extension.pglogical,

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -194,7 +194,7 @@ resource "postgresql_grant" "grant_usage_pglogical_schema_public_user" {
 
 # GRANT SELECT on ALL TABLES in SCHEMA pglogical to USER on all databases to get replication information from source databases.
 resource "postgresql_grant" "grant_select_table_pglogical_schema_migration_user" {
-  for_each    = local.upgradable ? toset(local.databases) : []
+  for_each    = local.upgradable ? toset(local.migration_databases) : []
   database    = each.value
   role        = postgresql_role.migration[0].name
   schema      = "pglogical"
@@ -210,7 +210,7 @@ resource "postgresql_grant" "grant_select_table_pglogical_schema_migration_user"
 
 # GRANT SELECT on ALL TABLES in SCHEMA SCHEMA to USER on all schemas (aside from the information schema and schemas starting with "pg_") on each database to migrate.
 resource "postgresql_grant" "grant_select_table_public_schema_migration_user" {
-  for_each    = local.upgradable ? toset(local.databases) : []
+  for_each    = local.upgradable ? toset(local.migration_databases) : []
   database    = each.value
   role        = postgresql_role.migration[0].name
   schema      = "public"

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -139,7 +139,7 @@ resource "postgresql_grant" "grant_connect_db_migration_user" {
   database    = each.value
   role        = postgresql_role.migration[0].name
   object_type = "database"
-  privileges  = ["CONNECT"]
+  privileges  = ["CONNECT" , "TEMPORARY"]
   depends_on = [
     postgresql_role.migration
   ]

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -137,7 +137,7 @@ resource "postgresql_role" "migration" {
 resource "postgresql_grant" "grant_usage_migration" {
   for_each    = local.upgradable ? toset(local.databases) : []
   database    = each.value
-  role        = postgresql_role.migration.name
+  role        = postgresql_role.migration[0].name
   schema      = "public"
   object_type = "schema"
   privileges  = ["USAGE"]
@@ -166,7 +166,7 @@ resource "postgresql_grant" "grant_usage_pglogical" {
 resource "postgresql_grant" "grant_select_pglogical" {
   for_each    = local.upgradable ? toset(local.databases) : []
   database    = each.value
-  role        = postgresql_role.migration.name
+  role        = postgresql_role.migration[0].name
   schema      = "pglogical"
   object_type = "table"
 
@@ -181,7 +181,7 @@ resource "postgresql_grant" "grant_select_pglogical" {
 resource "postgresql_grant" "grant_select_public" {
   for_each    = local.upgradable ? toset(local.databases) : []
   database    = each.value
-  role        = postgresql_role.migration.name
+  role        = postgresql_role.migration[0].name
   schema      = "public"
   object_type = "table"
 

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -139,7 +139,7 @@ resource "postgresql_grant" "grant_connect_db_migration_user" {
   database    = each.value
   role        = postgresql_role.migration[0].name
   object_type = "database"
-  privileges  = ["CONNECT" , "TEMPORARY"]
+  privileges  = ["CONNECT", "TEMPORARY"]
   depends_on = [
     postgresql_role.migration
   ]

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -117,6 +117,30 @@ resource "random_password" "admin" {
   special = false
 }
 
+resource "random_password" "migration" {
+  length  = 20
+  special = false
+}
+
+resource "postgresql_role" "migration" {
+  name     = "${local.instance_name}-migration"
+  password = random_password.migration.result
+  login    = true
+}
+
+resource "postgresql_grant" "migration" {
+  database    = postgresql_database.db.name
+  role        = postgresql_role.big_query.name
+  object_type = "database"
+
+  privileges = ["CONNECT"]
+
+  depends_on = [
+    google_bigquery_connection.db,
+    postgresql_grant.grant_all
+  ]
+}
+
 resource "google_sql_user" "admin" {
   name     = "${local.instance_name}-admin"
   instance = google_sql_database_instance.instance.name

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -160,6 +160,21 @@ resource "postgresql_grant" "grant_usage_migration" {
   ]
 }
 
+resource "postgresql_grant" "grant_usage_postgres" {
+  count       = local.upgradable ? 1 : 0
+  database    = "postgres"
+  role        = postgresql_role.migration[0].name
+  schema      = "pglogical"
+  object_type = "schema"
+
+  privileges = ["USAGE"]
+
+  depends_on = [
+    postgresql_extension.pglogical,
+    postgresql_role.migration
+  ]
+}
+
 resource "postgresql_grant" "grant_usage_pglogical" {
   for_each    = local.upgradable ? toset(local.databases) : []
   database    = each.value

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -25,10 +25,13 @@ resource "google_database_migration_service_connection_profile" "connection_prof
     host         = google_sql_database_instance.instance.private_ip_address
     port         = local.database_port
 
-    username = google_sql_user.migration.name
-    password = google_sql_user.migration.password
+    username = postgresql_role.migration.name
+    password = postgresql_role.migration.password
   }
-  depends_on = [google_sql_database_instance.instance]
+  depends_on = [
+    postgresql_role.migration,
+    google_sql_database_instance.instance
+  ]
 }
 
 resource "google_sql_database_instance" "instance" {

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -160,8 +160,23 @@ resource "postgresql_grant" "grant_usage_migration" {
   ]
 }
 
-# GRANT USAGE on SCHEMA pglogical to PUBLIC; on each database to migrate.
 resource "postgresql_grant" "grant_usage_pglogical" {
+  for_each    = local.upgradable ? toset(local.databases) : []
+  database    = each.value
+  role        = postgresql_role.migration[0].name
+  schema      = "pglogical"
+  object_type = "schema"
+
+  privileges = ["USAGE"]
+
+  depends_on = [
+    postgresql_extension.pglogical,
+    postgresql_role.migration
+  ]
+}
+
+# GRANT USAGE on SCHEMA pglogical to PUBLIC; on each database to migrate.
+resource "postgresql_grant" "grant_usage_public_pglogical" {
   for_each    = local.upgradable ? toset(local.databases) : []
   database    = each.value
   role        = "public"

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -25,8 +25,8 @@ resource "google_database_migration_service_connection_profile" "connection_prof
     host         = google_sql_database_instance.instance.private_ip_address
     port         = local.database_port
 
-    username = postgresql_role.migration.name
-    password = postgresql_role.migration.password
+    username = postgresql_role.migration[0].name
+    password = postgresql_role.migration[0].password
   }
   depends_on = [
     postgresql_role.migration,

--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -62,6 +62,7 @@ locals {
   tier                          = var.tier
   max_connections               = var.max_connections
   databases                     = var.databases
+  migration_databases           = concat(var.databases, ["postgres"])
   big_query_viewers             = var.big_query_viewers
   replication                   = var.replication
   provision_read_replica        = var.provision_read_replica


### PR DESCRIPTION
This PR removes the dependency on the database admin and creates a new `migration` role which contains all the necessary permissions for setting up the database migration via the Database Migration Service.