### PR TITLE
fix: destroy step with targetting the admin user

### DIFF
--- a/examples/gcp/Makefile
+++ b/examples/gcp/Makefile
@@ -45,6 +45,8 @@ destroy-bootstrap:
 
 destroy-postgresql:
 	cd postgresql \
-		&& $(TF) destroy
+		&& $(TF) destroy \
+		&& tf state rm module.postgresql.google_sql_user.admin \
+		&& $(TF) destroy 
 
 .PHONY: bootstrap inception platform smoketest postgresql


### PR DESCRIPTION
This PR adds

```
tf state rm module.postgresql.google_sql_user.admin \
		&& $(TF) destroy
```
to the teardown step which worked while doing the test on bastion. 