### PR TITLE
fix: Resolve concurrent table update issue 

### DIFF
--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -155,7 +155,7 @@ resource "postgresql_grant" "grant_usage_public_schema_migration_user" {
 
   depends_on = [
     postgresql_role.migration,
-    postgresqlpostgresql_grant.grant_connect_db_migration_user
+    postgresql_grant.grant_connect_db_migration_user
   ]
 }
 

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -142,6 +142,7 @@ resource "postgresql_grant" "grant_connect_db_migration_user" {
   privileges  = ["CONNECT", "TEMPORARY"]
   depends_on = [
     google_sql_database_instance.instance,
+    module.database,
     postgresql_role.migration
   ]
 }
@@ -156,6 +157,7 @@ resource "postgresql_grant" "grant_usage_public_schema_migration_user" {
 
   depends_on = [
     postgresql_role.migration,
+    module.database,
     postgresql_grant.grant_connect_db_migration_user
   ]
 }
@@ -170,6 +172,7 @@ resource "postgresql_grant" "grant_usage_pglogical_schema_migration_user" {
 
   depends_on = [
     postgresql_role.migration,
+    module.database,
     postgresql_extension.pglogical,
     postgresql_grant.grant_usage_public_schema_migration_user
   ]
@@ -186,6 +189,7 @@ resource "postgresql_grant" "grant_usage_pglogical_schema_public_user" {
 
   depends_on = [
     postgresql_role.migration,
+    module.database,
     postgresql_extension.pglogical,
     postgresql_grant.grant_usage_pglogical_schema_migration_user
   ]
@@ -202,6 +206,7 @@ resource "postgresql_grant" "grant_select_table_pglogical_schema_migration_user"
 
   depends_on = [
     postgresql_role.migration,
+    module.database,
     postgresql_extension.pglogical,
     postgresql_grant.grant_usage_pglogical_schema_public_user
   ]
@@ -218,6 +223,7 @@ resource "postgresql_grant" "grant_select_table_public_schema_migration_user" {
 
   depends_on = [
     postgresql_role.migration,
+    module.database,
     postgresql_grant.grant_select_table_pglogical_schema_migration_user
   ]
 }

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -141,6 +141,7 @@ resource "postgresql_grant" "grant_connect_db_migration_user" {
   object_type = "database"
   privileges  = ["CONNECT", "TEMPORARY"]
   depends_on = [
+    google_sql_database_instance.instance,
     postgresql_role.migration
   ]
 }
@@ -168,8 +169,8 @@ resource "postgresql_grant" "grant_usage_pglogical_schema_migration_user" {
   privileges  = ["USAGE"]
 
   depends_on = [
-    postgresql_extension.pglogical,
     postgresql_role.migration,
+    postgresql_extension.pglogical,
     postgresql_grant.grant_usage_public_schema_migration_user
   ]
 }
@@ -184,8 +185,8 @@ resource "postgresql_grant" "grant_usage_pglogical_schema_public_user" {
   privileges = ["USAGE"]
 
   depends_on = [
-    postgresql_extension.pglogical,
     postgresql_role.migration,
+    postgresql_extension.pglogical,
     postgresql_grant.grant_usage_pglogical_schema_migration_user
   ]
 }

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -96,8 +96,8 @@ resource "google_sql_database_instance" "instance" {
     }
 
     backup_configuration {
-      enabled                        = true
-      point_in_time_recovery_enabled = true
+      enabled                        = local.backup
+      point_in_time_recovery_enabled = local.backup
     }
 
     ip_configuration {

--- a/modules/postgresql/gcp/main.tf
+++ b/modules/postgresql/gcp/main.tf
@@ -96,8 +96,8 @@ resource "google_sql_database_instance" "instance" {
     }
 
     backup_configuration {
-      enabled                        = local.backup
-      point_in_time_recovery_enabled = local.backup
+      enabled                        = true
+      point_in_time_recovery_enabled = true
     }
 
     ip_configuration {

--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -51,12 +51,6 @@ variable "upgradable" {
   default     = false
 }
 
-variable "backup" {
-  description = "Backup is enabled for the PostgreSQL instance"
-  type        = bool
-  default     = true
-}
-
 locals {
   gcp_project                   = var.gcp_project
   vpc_name                      = var.vpc_name
@@ -75,5 +69,4 @@ locals {
   big_query_connection_location = var.big_query_connection_location
   upgradable                    = var.upgradable
   database_port                 = 5432
-  backup                        = var.backup
 }

--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -51,6 +51,12 @@ variable "upgradable" {
   default     = false
 }
 
+variable "backup" {
+  description = "Backup is enabled for the PostgreSQL instance"
+  type        = bool
+  default     = true
+}
+
 locals {
   gcp_project                   = var.gcp_project
   vpc_name                      = var.vpc_name
@@ -69,4 +75,5 @@ locals {
   big_query_connection_location = var.big_query_connection_location
   upgradable                    = var.upgradable
   database_port                 = 5432
+  backup                        = var.backup
 }


### PR DESCRIPTION
This PR does:

- Adds a dependency between `postgres_grant` configurations to prevent concurrent operations on a single schema, which would otherwise throw an error.

