### PR TITLE
ci: tf module to find common latest k8s version across 3 regions

### DIFF
--- a/ci/k8s-upgrade/main.tf
+++ b/ci/k8s-upgrade/main.tf
@@ -1,10 +1,40 @@
-data "google_container_engine_versions" "central1b" {
-  provider       = google-beta
-  location       = "europe-west6"
+locals {
   version_prefix = "1.28."
   project        = "galoy-infra-testflight"
 }
 
+data "google_container_engine_versions" "euwest6" {
+  provider       = google-beta
+  location       = "europe-west6"
+  version_prefix = local.version_prefix
+  project        = local.project
+}
+
+data "google_container_engine_versions" "uscentral1" {
+  provider       = google-beta
+  location       = "us-central1"
+  version_prefix = local.version_prefix
+  project        = local.project
+}
+
+data "google_container_engine_versions" "useast1" {
+  provider       = google-beta
+  location       = "us-east1"
+  version_prefix = local.version_prefix
+  project        = local.project
+}
+
+locals {
+  # Convert outputs to sets
+  euwest6_versions = toset(data.google_container_engine_versions.euwest6.valid_master_versions)
+  uscentral1_versions = toset(data.google_container_engine_versions.uscentral1.valid_master_versions)
+  useast1_versions = toset(data.google_container_engine_versions.useast1.valid_master_versions)
+
+  # Find the intersection of all sets, i.e., common versions
+  common_versions = setintersection(local.euwest6_versions, local.uscentral1_versions, local.useast1_versions)
+}
+
 output "latest_version" {
-  value = data.google_container_engine_versions.central1b.latest_node_version
+  # Convert the set back to a list, sort it, and get the last element which is the highest version
+  value = length(local.common_versions) > 0 ? sort(tolist(local.common_versions))[length(local.common_versions) - 1] : ""
 }

--- a/ci/k8s-upgrade/main.tf
+++ b/ci/k8s-upgrade/main.tf
@@ -26,9 +26,9 @@ data "google_container_engine_versions" "useast1" {
 
 locals {
   # Convert outputs to sets
-  euwest6_versions = toset(data.google_container_engine_versions.euwest6.valid_master_versions)
+  euwest6_versions    = toset(data.google_container_engine_versions.euwest6.valid_master_versions)
   uscentral1_versions = toset(data.google_container_engine_versions.uscentral1.valid_master_versions)
-  useast1_versions = toset(data.google_container_engine_versions.useast1.valid_master_versions)
+  useast1_versions    = toset(data.google_container_engine_versions.useast1.valid_master_versions)
 
   # Find the intersection of all sets, i.e., common versions
   common_versions = setintersection(local.euwest6_versions, local.uscentral1_versions, local.useast1_versions)

--- a/ci/tasks/check-and-upgrade-k8s.sh
+++ b/ci/tasks/check-and-upgrade-k8s.sh
@@ -3,11 +3,15 @@
 set -eu
 
 source pipeline-tasks/ci/tasks/helpers.sh
-
 pushd pipeline-tasks/ci/k8s-upgrade
 
 terraform init && terraform apply -auto-approve
 LATEST_VERSION="$(terraform output -json | jq -r .latest_version.value)"
+
+if [[ $LATEST_VERSION == "" ]]; then
+  echo "Failed to get latest version"
+  exit 1
+fi
 
 popd
 


### PR DESCRIPTION
```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

latest_version = "1.28.13-gke.1006000"
```