### PR TITLE
fix: CI failing due to destination database PG16 version

### DIFF
--- a/modules/postgresql/gcp/variables.tf
+++ b/modules/postgresql/gcp/variables.tf
@@ -26,7 +26,7 @@ variable "database_version" {
   default = "POSTGRES_14"
 }
 variable "destination_database_version" {
-  default = "POSTGRES_16"
+  default = "POSTGRES_15"
 }
 variable "big_query_viewers" {
   default = []


### PR DESCRIPTION
This PR updates the destination database version from 16 to 15. According to the documentation:

> If the database version for your instance is PostgreSQL 16 or later, the default edition is Cloud SQL Enterprise Plus.

However, the current CI configuration assumes our edition is `Enterprise` resulting in a failure due to `Enterprise Plus` not recognizing the custom configuration syntax.

cc: https://cloud.google.com/sql/docs/postgres/create-instance#machine-types