### PR TITLE
feat: Remove lnd from default and make it optional

### DIFF
--- a/modules/platform/gcp/variables.tf
+++ b/modules/platform/gcp/variables.tf
@@ -32,7 +32,7 @@ variable "max_default_node_count" {
   default = 3
 }
 variable "deploy_lnd_ips" {
-  default = true
+  default = false
 }
 
 locals {


### PR DESCRIPTION
 The change modifies the default value of the `deploy_lnd_ips` variable from `true` to `false` in `modules/platform/gcp/variables.tf` file.