### PR TITLE
chore: Mark the system as PRODUCTION SYSTEM on the prompt

### DIFF
--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -119,5 +119,5 @@ curl -sL https://deb.nodesource.com/setup_20.x | bash - \
 apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
 
 %{ if prod_system }
-sed -i 's/PS1='\''${debian_chroot:+($debian_chroot)}\\[\\033\[01;32m\\]\\u@\\h\\[\\033\[00m\\]:\\[\\033\[01;34m\\]\\w\\[\\033\[00m\\]\\$ '\''/PS1='\''\\[\\033[01;31m\\]PRODUCTION SYSTEM\\[\\033[00m\\]\\n${debian_chroot:+($debian_chroot)}\\[\\033[01;32m\\]\\u@\\h\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\$ '\''/1' /etc/skel/.bashrc
+sed -i '/PS1=.*\[01;32m.*\[01;34m/s/PS1=.*$/PS1='\''\\[\\033[01;31m\\]PRODUCTION SYSTEM\\[\\033[00m\\]\\n${debian_chroot:+($debian_chroot)}\\[\\033[01;32m\\]\\u@\\h\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\$ '\''/1' /etc/skel/.bashrc
 %{ endif }

--- a/modules/inception/gcp/bastion-startup.tmpl
+++ b/modules/inception/gcp/bastion-startup.tmpl
@@ -1,6 +1,30 @@
 #!/bin/bash
 
-sed -i'' 's/pam_mkhomedir.so$/pam_mkhomedir.so umask=0077/' /etc/pam.d/sshd # Make all files private by default
+# Test this script e.g. with:
+# * Creating a Dockerfile like (check the image name):
+# FROM ubuntu:24.04
+
+# COPY bastion-startup.tmpl /startup.sh
+# RUN chmod +x /startup.sh
+
+# CMD ["/startup.sh"]
+# * comment out the tmpl-stuff on line 62-70 and around line 120
+# * adjust the variables below
+# * run: 
+# cp ../.terraform/modules/inception/modules/inception/gcp/bastion-startup.tmpl ./startup.sh && docker build -t bastion-test . && docker run -it \
+#   -e bria_version=0.1.108 \
+#   -e bitcoin_version=25.2 \
+#   -e cepler_version=0.7.15 \
+#   -e lnd_version=0.18.0-beta \
+#   -e kubectl_version=1.30.4 \
+#   -e k9s_version=0.32.5 \
+#   -e bos_version=18.2.0 \
+#   -e kratos_version=0.11.1 \
+#   -e opentofu_version=1.8.2 -e cluster_name=blink-org-test-cluster -e zone=us-east1-b -e project=blink-org-test \
+#   bastion-test bash
+
+
+set -eux
 
 curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
 apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
@@ -93,3 +117,7 @@ curl -sL https://deb.nodesource.com/setup_20.x | bash - \
   && ln -s ../lib/node_modules/balanceofsatoshis/bos /usr/bin/
 
 apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+
+%{ if prod_system }
+sed -i 's/PS1='\''${debian_chroot:+($debian_chroot)}\\[\\033\[01;32m\\]\\u@\\h\\[\\033\[00m\\]:\\[\\033\[01;34m\\]\\w\\[\\033\[00m\\]\\$ '\''/PS1='\''\\[\\033[01;31m\\]PRODUCTION SYSTEM\\[\\033[00m\\]\\n${debian_chroot:+($debian_chroot)}\\[\\033[01;32m\\]\\u@\\h\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\$ '\''/1' /etc/skel/.bashrc
+%{ endif }

--- a/modules/inception/gcp/bastion.tf
+++ b/modules/inception/gcp/bastion.tf
@@ -58,6 +58,7 @@ resource "google_compute_instance" "bastion" {
     bos_version : local.bos_version
     kratos_version : local.kratos_version
     opentofu_version : local.opentofu_version
+    prod_system : var.prod_system
   })
 
   depends_on = [

--- a/modules/inception/gcp/variables.tf
+++ b/modules/inception/gcp/variables.tf
@@ -9,6 +9,10 @@ variable "primary_zone" {
 variable "cluster_zone" {
   default = ""
 }
+variable "prod_system" {
+  type    = bool
+  default = false
+}
 variable "bastion_machine_type" {
   default = "e2-micro"
 }


### PR DESCRIPTION
This will result in a prompt which looks like this if `prod_system` is true.
<img width="356" alt="Screenshot 2025-02-24 at 10 12 19" src="https://github.com/user-attachments/assets/fa0a5033-4e4c-45da-b6dd-dbfab53ee656" />

However that only works for new users. To quickly change your existing prompt:
```
sed -i '/PS1=.*\[01;32m.*\[01;34m/s/PS1=.*$/PS1='\''\\[\\033[01;31m\\]PRODUCTION SYSTEM\\[\\033[00m\\]\\n${debian_chroot:+($debian_chroot)}\\[\\033[01;32m\\]\\u@\\h\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\$ '\''/1' ~/.bashrc
```