### PR TITLE
chore: switch terraform to tofu in fmt pipeline

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -7,9 +7,9 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code into workspace directory
-      uses: actions/checkout@v2
-    - name: Terraform fmt
-      uses: hashicorp/setup-terraform@v2
-    - run: terraform fmt -recursive .
-    - run: git diff --exit-code
+      - name: Checkout code into workspace directory
+        uses: actions/checkout@v2
+      - name: Tofu fmt
+        uses: opentofu/setup-opentofu@v1
+      - run: tofu fmt -recursive .
+      - run: git diff --exit-code


### PR DESCRIPTION
fixes [#217](https://github.com/GaloyMoney/galoy-infra/issues/217)

This PR updates the GitHub Actions workflow to replace `terraform fmt` with `tofu fmt`

Replaces `hashicorp/setup-terraform` with a `opentofu/setup-opentofu@v1`. here is the [doc](https://github.com/marketplace/actions/opentofu-setup-tofu)
Runs `tofu fmt -recursive .` instead of `terraform fmt -recurisve .`