### PR TITLE
switched to tofu

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -7,9 +7,9 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code into workspace directory
-      uses: actions/checkout@v2
-    - name: Terraform fmt
-      uses: hashicorp/setup-terraform@v2
-    - run: terraform fmt -recursive .
-    - run: git diff --exit-code
+      - name: Checkout code into workspace directory
+        uses: actions/checkout@v2
+      - name: OpenTofu setup
+        uses: opentofu/setup-opentofu@v2
+      - run: tofu fmt -recursive .
+      - run: git diff --exit-code


### PR DESCRIPTION
fixes #217 

This PR replaces the Terraform setup with OpenTofu in our GitHub Actions workflow. It updates the formatter command from `terraform fmt -recursive .` to `tofu fmt -recursive .` .